### PR TITLE
Support AWS cloudwatch datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # grafana-api-golang-client
+
 Grafana HTTP API Client for Go
+
+## Tests
+
+To run the tests:
+
+```
+go test
+```

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -50,9 +51,9 @@ func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request,
 
 	if os.Getenv("GF_LOG") != "" {
 		if body == nil {
-			fmt.Println("request to ", url.String(), "with no body data")
+			log.Println("request to ", url.String(), "with no body data")
 		} else {
-			fmt.Println("request to ", url.String(), "with body data", body.(*bytes.Buffer).String())
+			log.Println("request to ", url.String(), "with body data", body.(*bytes.Buffer).String())
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -46,11 +47,15 @@ func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request,
 	if c.key != "" {
 		req.Header.Add("Authorization", c.key)
 	}
-	if body == nil {
-		fmt.Println("request to ", url.String(), "with no body data")
-	} else {
-		fmt.Println("request to ", url.String(), "with body data", body.(*bytes.Buffer).String())
+
+	if os.Getenv("GF_LOG") != "" {
+		if body == nil {
+			fmt.Println("request to ", url.String(), "with no body data")
+		} else {
+			fmt.Println("request to ", url.String(), "with body data", body.(*bytes.Buffer).String())
+		}
 	}
+
 	req.Header.Add("Content-Type", "application/json")
 	return req, err
 }

--- a/datasource.go
+++ b/datasource.go
@@ -25,6 +25,21 @@ type DataSource struct {
 	BasicAuth         bool   `json:"basicAuth"`
 	BasicAuthUser     string `json:"basicAuthUser,omitempty"`
 	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
+
+	JSONData       JSONData       `json:"jsonData,omitempty"`
+	SecureJSONData SecureJSONData `json:"secureJsonData,omitempty"`
+}
+
+// JSONData is a representation of the datasource `jsonData` property
+type JSONData struct {
+	AuthType      string `json:"authType,omitempty"`
+	DefaultRegion string `json:"defaultRegion,omitempty"`
+}
+
+// SecureJSONData is a representation of the datasource `secureJsonData` property
+type SecureJSONData struct {
+	AccessKey string `json:"accessKey,omitempty"`
+	SecretKey string `json:"secretKey,omitempty"`
 }
 
 func (c *Client) NewDataSource(s *DataSource) (int64, error) {

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -1,0 +1,68 @@
+package gapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gobs/pretty"
+)
+
+func gapiTestTools(code int, body string) (*httptest.Server, *Client) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, body)
+	}))
+
+	tr := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(server.URL)
+		},
+	}
+
+	httpClient := &http.Client{Transport: tr}
+
+	url := url.URL{
+		Scheme: "http",
+		Host:   "my-grafana.com",
+	}
+
+	client := &Client{"my-key", url, httpClient}
+
+	return server, client
+}
+
+func TestNewDataSource(t *testing.T) {
+	server, client := gapiTestTools(200, createdDataSourceJSON)
+	defer server.Close()
+
+	ds := &DataSource{
+		Name:      "foo",
+		Type:      "cloudwatch",
+		URL:       "http://some-url.com",
+		Access:    "access",
+		IsDefault: true,
+		JSONData: JSONData{
+			AuthType:      "keys",
+			DefaultRegion: "us-east-1",
+		},
+		SecureJSONData: SecureJSONData{
+			AccessKey: "123",
+			SecretKey: "456",
+		},
+	}
+
+	created, err := client.NewDataSource(ds)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(pretty.PrettyFormat(created))
+
+	if created != 1 {
+		t.Error("datasource creation response should return the created datasource ID")
+	}
+}

--- a/grafana_fixtures_test.go
+++ b/grafana_fixtures_test.go
@@ -1,0 +1,5 @@
+package gapi
+
+const (
+	createdDataSourceJSON = `{"id":1,"message":"Datasource added", "name": "test_datasource"}`
+)


### PR DESCRIPTION
This is PR seeks to add support to `go-grafana-api` for Grafana's AWS cloudwatch datasource, which requires `jsonData` and `secureJsonData` fields in the JSON `POST`'d during cloudwatch-datasource-creation as [documented here](http://docs.grafana.org/http_api/data_source/#create-data-source).

This PR is also necessary to address [terraform-providers/terraform-provider-grafana issue #4](https://github.com/terraform-providers/terraform-provider-grafana/issues/4).

Thanks!