### PR TITLE
Concat request path to Base URL path.

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -38,9 +39,9 @@ func New(auth, baseURL string) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(method, requestPath string, body io.Reader) (*http.Request, error) {
 	url := c.baseURL
-	url.Path = path
+	url.Path = path.Join(url.Path, requestPath)
 	req, err := http.NewRequest(method, url.String(), body)
 	if err != nil {
 		return req, err


### PR DESCRIPTION
If the base URL includes a path component, don’t overwrite this with the
request path. 
This is necessary when Grafana is running behind a reverse
proxy that is doing path based routing.